### PR TITLE
`programs.ghostty.package` no longer defaults to null

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -169,7 +169,6 @@ in {
       # it if you're managing it externally, e.g. using the signed
       # macOS builds.
       nullable = true;
-      default = null;
     };
 
     extraConfig = mkOption {


### PR DESCRIPTION
Fixes #1
Since ghostty is now on nixpkgs unstable, it makes no sense to default the package to null.